### PR TITLE
Add Zenet AI demo scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ See [contributing guide](CONTRIBUTING.md). Reach out to us at [Discord](https://
 ## 📄 License
 
 Source code in this repository is made available under the [Apache License Version 2.0](LICENSE.md).
+
+
+## Zenet AI Demo
+Demo source located in [zenet-ai](./zenet-ai). Follow setup instructions in its README to run a minimal SaaS example.

--- a/zenet-ai/README.md
+++ b/zenet-ai/README.md
@@ -1,0 +1,27 @@
+# Zenet AI Demo
+
+This is a demo SaaS application showing how businesses can configure AI-powered voice agents.
+
+## Structure
+
+- `frontend` – React app built with Vite and Tailwind CSS
+- `backend` – Node.js Express server with MongoDB
+
+## Setup
+
+```
+cd backend
+npm install
+cp .env.example .env
+npm start
+```
+
+In another terminal:
+
+```
+cd frontend
+npm install
+npm run dev
+```
+
+The frontend expects the backend to run on `http://localhost:4000`.

--- a/zenet-ai/backend/.env.example
+++ b/zenet-ai/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=4000
+MONGODB_URI=mongodb://localhost/zenet-demo
+JWT_SECRET=supersecret

--- a/zenet-ai/backend/README.md
+++ b/zenet-ai/backend/README.md
@@ -1,0 +1,15 @@
+# Zenet AI Backend
+
+## Setup
+
+```bash
+npm install
+cp .env.example .env
+npm start
+```
+
+## API
+- `POST /api/auth/signup` - { email, password }
+- `POST /api/auth/login` - { email, password }
+- `POST /api/profile` - requires Authorization header `Bearer <token>`
+- `GET /api/profile` - get profile

--- a/zenet-ai/backend/models/AnalyticsData.js
+++ b/zenet-ai/backend/models/AnalyticsData.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const analyticsDataSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  callsAnswered: { type: Number, default: 0 },
+  bookingsMade: { type: Number, default: 0 },
+  feedbackCollected: { type: Number, default: 0 },
+  date: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('AnalyticsData', analyticsDataSchema);

--- a/zenet-ai/backend/models/CompanyProfile.js
+++ b/zenet-ai/backend/models/CompanyProfile.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const companyProfileSchema = new mongoose.Schema({
+  businessName: String,
+  contactEmail: String,
+  logoUrl: String
+});
+
+export default mongoose.model('CompanyProfile', companyProfileSchema);

--- a/zenet-ai/backend/models/Subscription.js
+++ b/zenet-ai/backend/models/Subscription.js
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const subscriptionSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  plan: String,
+  stripeCustomerId: String,
+  active: { type: Boolean, default: false }
+});
+
+export default mongoose.model('Subscription', subscriptionSchema);

--- a/zenet-ai/backend/models/User.js
+++ b/zenet-ai/backend/models/User.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  companyProfile: { type: mongoose.Schema.Types.ObjectId, ref: 'CompanyProfile' }
+});
+
+export default mongoose.model('User', userSchema);

--- a/zenet-ai/backend/models/VoiceAgentConfig.js
+++ b/zenet-ai/backend/models/VoiceAgentConfig.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const voiceAgentConfigSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  agentName: String,
+  voice: String,
+  tone: String,
+  language: { type: String, default: 'cs' }
+});
+
+export default mongoose.model('VoiceAgentConfig', voiceAgentConfigSchema);

--- a/zenet-ai/backend/package.json
+++ b/zenet-ai/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "zenet-ai-backend",
+  "version": "0.1.0",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.0",
+    "mongoose": "^7.0.0"
+  }
+}

--- a/zenet-ai/backend/routes/auth.js
+++ b/zenet-ai/backend/routes/auth.js
@@ -1,0 +1,34 @@
+import express from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = express.Router();
+
+router.post('/signup', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ email, password: hashed });
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    const user = await User.findOne({ email });
+    if (!user) throw new Error('User not found');
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) throw new Error('Invalid credentials');
+    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(401).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/zenet-ai/backend/routes/profile.js
+++ b/zenet-ai/backend/routes/profile.js
@@ -1,0 +1,30 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+import CompanyProfile from '../models/CompanyProfile.js';
+
+const router = express.Router();
+
+function auth(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.sendStatus(401);
+  try {
+    req.user = jwt.verify(token, process.env.JWT_SECRET);
+    next();
+  } catch {
+    res.sendStatus(403);
+  }
+}
+
+router.post('/', auth, async (req, res) => {
+  const profile = await CompanyProfile.create(req.body);
+  await User.findByIdAndUpdate(req.user.id, { companyProfile: profile._id });
+  res.json(profile);
+});
+
+router.get('/', auth, async (req, res) => {
+  const user = await User.findById(req.user.id).populate('companyProfile');
+  res.json(user.companyProfile);
+});
+
+export default router;

--- a/zenet-ai/backend/src/index.js
+++ b/zenet-ai/backend/src/index.js
@@ -1,0 +1,21 @@
+import express from 'express';
+import mongoose from 'mongoose';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+import authRoutes from '../routes/auth.js';
+import profileRoutes from '../routes/profile.js';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+app.use('/api/profile', profileRoutes);
+
+const PORT = process.env.PORT || 4000;
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost/zenet-demo').then(() => {
+  app.listen(PORT, () => console.log(`Server running on ${PORT}`));
+}).catch(err => console.error(err));

--- a/zenet-ai/frontend/index.html
+++ b/zenet-ai/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Zenet AI</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+  </body>
+</html>

--- a/zenet-ai/frontend/package.json
+++ b/zenet-ai/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "zenet-ai-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/zenet-ai/frontend/postcss.config.js
+++ b/zenet-ai/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/zenet-ai/frontend/src/index.css
+++ b/zenet-ai/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/zenet-ai/frontend/src/main.jsx
+++ b/zenet-ai/frontend/src/main.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './pages/App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/zenet-ai/frontend/src/pages/App.jsx
+++ b/zenet-ai/frontend/src/pages/App.jsx
@@ -1,0 +1,8 @@
+import { useState } from 'react';
+import Landing from './Landing';
+import Dashboard from './Dashboard';
+
+export default function App() {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+  return token ? <Dashboard token={token} /> : <Landing onAuth={setToken} />;
+}

--- a/zenet-ai/frontend/src/pages/Dashboard.jsx
+++ b/zenet-ai/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function Dashboard({ token }) {
+  const [profile, setProfile] = useState(null);
+  useEffect(() => {
+    fetch('http://localhost:4000/api/profile', {
+      headers: { Authorization: `Bearer ${token}` }
+    })
+      .then(res => res.json())
+      .then(setProfile);
+  }, [token]);
+
+  return (
+    <div className="p-8">
+      <h2 className="text-2xl font-bold mb-4">Dashboard</h2>
+      {profile ? (
+        <div>
+          <p>Business: {profile.businessName}</p>
+          <p>Contact: {profile.contactEmail}</p>
+        </div>
+      ) : (
+        <p>No profile set up.</p>
+      )}
+    </div>
+  );
+}

--- a/zenet-ai/frontend/src/pages/Landing.jsx
+++ b/zenet-ai/frontend/src/pages/Landing.jsx
@@ -1,0 +1,34 @@
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+
+export default function Landing({ onAuth }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const signup = async () => {
+    const res = await fetch('http://localhost:4000/api/auth/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if (data.token) {
+      localStorage.setItem('token', data.token);
+      onAuth(data.token);
+    } else {
+      setError(data.error);
+    }
+  };
+
+  return (
+    <div className="p-8 text-center">
+      <motion.h1 initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-4xl font-bold mb-4">Zenet AI</motion.h1>
+      <p className="mb-6">Configure your AI voice agent in minutes.</p>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      <input className="border p-2 mr-2" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
+      <input className="border p-2 mr-2" placeholder="Password" type="password" value={password} onChange={e => setPassword(e.target.value)} />
+      <button className="bg-blue-500 text-white px-4 py-2" onClick={signup}>Sign Up</button>
+    </div>
+  );
+}

--- a/zenet-ai/frontend/tailwind.config.js
+++ b/zenet-ai/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- add Zenet AI sample app under `zenet-ai` folder
- implement backend Express server with auth and profile routes
- implement frontend Vite React app with simple landing and dashboard
- document setup in README
- link new demo from root README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ee892a88328bf765de7e9ac41e4